### PR TITLE
Add name as an additional output

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This *GitHub Action* extracts GAV from `pom.xml`, i.e.:
  * `groupId`
  * `artifactId`
  * `version`
+ * `name`
 
 Why should I need this? For example, to **name** and **tag** a Docker image built upon your artifact or **pass as parameters** to a dispatched workflow.
 
@@ -27,6 +28,7 @@ This action expects you to have `maven` available in your workflow environment
 | `group-id` | Group Id of your project |
 | `artifact-id` | Artifact Id of your project |
 | `version` | Version of your project |
+| `name` | Name of your project |
 
 ## Example usage
 
@@ -53,5 +55,6 @@ jobs:
         echo ${{ steps.extract.outputs.group-id }}
         echo ${{ steps.extract.outputs.artifact-id }}
         echo ${{ steps.extract.outputs.version }}
+        echo ${{ steps.extract.outputs.name }}
       shell: bash
 ```

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,9 @@ outputs:
   version:
     description: Version
     value: ${{ steps.evaluate.outputs.version }}
+  name:
+    description: Name
+    value: ${{ steps.evaluate.outputs.name }}
 runs:
   using: 'composite'
   steps:
@@ -27,4 +30,5 @@ runs:
         echo "::set-output name=group-id::$(mvn -f ${{ inputs.pom-location }} org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=project.groupId -q -DforceStdout)"
         echo "::set-output name=artifact-id::$(mvn -f ${{ inputs.pom-location }} org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=project.artifactId -q -DforceStdout)"
         echo "::set-output name=version::$(mvn -f ${{ inputs.pom-location }} org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=project.version -q -DforceStdout)"
+        echo "::set-output name=name::$(mvn -f ${{ inputs.pom-location }} org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=project.name -q -DforceStdout)"
       shell: bash


### PR DESCRIPTION
In my workflows I often create GitHub releases upon successful build / deployment. The name of the release is almost always identical to the name specified in the POM. So I thought it could be useful to add `name` as an additional output. 